### PR TITLE
Improve token flow

### DIFF
--- a/getData.js
+++ b/getData.js
@@ -2,9 +2,11 @@ const axios = require("axios");
 const dotenv = require("dotenv");
 const fs = require("fs-extra");
 const path = require("path");
-dotenv.config();
 
 exports.getData = async () => {
+  // Don't eager load because the key might not be set yet.
+  dotenv.config();
+
   let cfg;
 
   try {

--- a/portfolio.js
+++ b/portfolio.js
@@ -36,8 +36,8 @@ function getChoice(theQuestion) {
 async function setToken() {
   try {
     const token = await question(
-      "\n// Github token should have atleast public_repo, read:user permissions\n" +
-        "// After setting the token, you have to restart the program to build the site.\n" +
+      "\n// Github token should have at least public_repo, read:user permissions\n" +
+        "// A token can be created at https://github.com/settings/tokens/new .\n" +
         "Github token: "
     );
     await fs.outputFile(`./.env`, `GITHUB_TOKEN="${token}"`);


### PR DESCRIPTION
- Tell the users where to get a token.
- Allow to build right after getting a token, without having to reboot.