### PR TITLE
Fix repo cards overlap

### DIFF
--- a/resource/index.html
+++ b/resource/index.html
@@ -67,11 +67,7 @@
       </div>
       <!-- Repository Block -->
       <div id="repo-block">
-        <div
-          id="repo-grid"
-          class="grid"
-          data-masonry='{ "itemSelector": ".grid-item", "gutter": 20, "horizontalOrder": true, "columnWidth": 350, "fitWidth": true }'
-        >
+        <div id="repo-grid" class="grid">
           <!-- repository cards go here -->
         </div>
       </div>

--- a/resource/index.js
+++ b/resource/index.js
@@ -1,6 +1,5 @@
-//              Dark mode toggle
+//          Dark mode toggle
 // @SEE https://ryanfeigenbaum.com/dark-mode/
-//
 if (window.CSS && CSS.supports("color", "var(--primary)")) {
   var toggleColorMode = function toggleColorMode(e) {
     // Switch to Light Mode
@@ -30,3 +29,18 @@ if (window.CSS && CSS.supports("color", "var(--primary)")) {
   var btnContainer = document.querySelector(".color-mode-toggle");
   btnContainer.style.display = "none";
 }
+
+//          Masonry for the repository cards
+// @SEE https://masonry.desandro.com/
+let msnry = new Masonry(".grid", {
+  itemSelector: ".grid-item",
+  gutter: 20,
+  horizontalOrder: true,
+  columnWidth: 350,
+  fitWidth: true,
+});
+
+// Force masonry reload once page is ready to prevent overlap
+window.onload = function () {
+  msnry.layout();
+};


### PR DESCRIPTION
Masonry is now called in index.js and reloads the layout on page load.

Fixes #7 